### PR TITLE
fix(auth): preserve admin password when persisting refresh token

### DIFF
--- a/neon_hub_config/main.py
+++ b/neon_hub_config/main.py
@@ -96,12 +96,24 @@ class HanaClient:
             logger.warning("Failed to reach HANA for token refresh: %s", e)
 
     def _save_token(self):
+        # Preserve the admin password the installer wrote alongside the
+        # refresh token. Without it, a restart after the first save
+        # has no fallback when the cached refresh token becomes
+        # unusable (network blip during refresh, refresh-token TTL
+        # expiry on a long-idle hub, etc.) — _refresh_access_token
+        # logs "missing credentials" and the QR pairing endpoint
+        # serves 503 forever. Future work: use HANA's /auth/refresh
+        # for the hot path and keep the password as a cold-recovery
+        # fallback only.
         try:
+            payload = {
+                "username": self._username,
+                "refresh_token": self._refresh_token,
+            }
+            if self._password:
+                payload["password"] = self._password
             with open(self._token_file, "w", encoding="utf-8") as f:
-                YAML().dump({
-                    "username": self._username,
-                    "refresh_token": self._refresh_token,
-                }, f)
+                YAML().dump(payload, f)
         except Exception as e:
             logger.warning("Failed to save updated token: %s", e)
 


### PR DESCRIPTION
## The bug

`HanaClient._save_token` writes the YAML with only `username` and `refresh_token`, dropping the `password` field the installer's `bootstrap-hub-admin.yaml` originally wrote alongside them.

The installer flow:

1. `bootstrap-hub-admin.yaml` writes `hub_admin.yaml` with `username`, `password`, `refresh_token`.
2. `neon-hub-config` starts, `_load_token()` reads all three, `_refresh_access_token()` runs (line 73-96), succeeds, calls `_save_token()` (line 92).
3. `_save_token()` rewrites the file **without** `password`.

From this point on, every subsequent restart can refresh as long as the cached refresh token is still valid. But once the refresh chain is broken (network blip, refresh-token TTL expiry on a long-idle hub, container redeploy after a week), `_refresh_access_token` logs ` "Cannot refresh HANA token: missing credentials"` and `is_available` stays `False` forever. The `/v1/pair` endpoint then returns 503.

## Reproduced in the wild

A hub installed two days ago hit this exact path. `stat hub_admin.yaml` showed Birth at install time and Modify ~7 seconds later (the first `_save_token`). Manually restoring the `password:` line to the YAML and restarting the container unblocked QR pairing — but without this fix, the next successful refresh would erase it again.

## The fix

Include `password` in the persisted dict when present. One narrow change in `_save_token`. Conservative — keeps the existing design intact and matches the contract the installer documented.

## Why not just stop persisting the password?

Considered, but the password is the only fallback when the cached refresh token chain breaks. Refresh-token-only hub-config is fragile against:

- Network errors during refresh
- Refresh-token TTL expiry (HANA default 7 days) on hubs that sit idle longer
- Container redeploys after a week+

The right next step is to use HANA's `/auth/refresh` endpoint for the hot path and only fall back to the stored password for cold recovery. That requires coordination with the installer's bootstrap flow, so it's left for a follow-up — flagged in the inline comment.

## Test plan

- [x] Static review: only one `_save_token` call site (`_refresh_access_token` at line 92), only one reader (`_load_token`); the change preserves the dropped field without affecting any other call path.
- [ ] On a hub with the fix deployed: confirm `cat hub_admin.yaml` shows `password:` after the first refresh.
- [ ] Restart the container, confirm subsequent QR generation still works.