### PR TITLE
feat: show clear config save errors in the UI

### DIFF
--- a/frontend/neon-hub-config/src/components/YAMLEditors.tsx
+++ b/frontend/neon-hub-config/src/components/YAMLEditors.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import Editor from "@monaco-editor/react";
 import { dump, load } from "js-yaml";
 import { RefreshCw, Save } from "lucide-react";
+import { apiErrorMessage } from "../lib/utils";
 
 interface ConfigEditorProps {
   title: string;
@@ -92,7 +93,12 @@ const ConfigEditor: React.FC<ConfigEditorProps> = ({
       });
 
       if (!saveResponse.ok) {
-        throw new Error(`Failed to save ${title} configuration`);
+        throw new Error(
+          await apiErrorMessage(
+            saveResponse,
+            `Failed to save ${title} configuration`
+          )
+        );
       }
 
       await fetchConfig

--- a/frontend/neon-hub-config/src/lib/utils.ts
+++ b/frontend/neon-hub-config/src/lib/utils.ts
@@ -5,6 +5,27 @@ import { API_BASE_URL } from "../components/HubManagementUI"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Extract a user-facing message from an API error response. The backend
+// sends {detail: {error, message}} for classified save failures and
+// {detail: string} for plain HTTP errors; anything else gets the fallback.
+export async function apiErrorMessage(
+  response: Response,
+  fallback: string
+): Promise<string> {
+  try {
+    const detail = (await response.json())?.detail;
+    if (typeof detail === "string" && detail) {
+      return detail;
+    }
+    if (typeof detail?.message === "string") {
+      return detail.message;
+    }
+  } catch {
+    // Response body was not JSON
+  }
+  return fallback;
+}
 // API utilities
 export const api = {
   // Method to update runtime configuration
@@ -63,7 +84,9 @@ export const api = {
     });
 
     if (!response.ok) {
-      throw new Error("Failed to save Neon configuration");
+      throw new Error(
+        await apiErrorMessage(response, "Failed to save Neon configuration")
+      );
     }
 
     return response.json();
@@ -77,7 +100,9 @@ export const api = {
     });
 
     if (!response.ok) {
-      throw new Error("Failed to save Diana configuration");
+      throw new Error(
+        await apiErrorMessage(response, "Failed to save Diana configuration")
+      );
     }
 
     return response.json();

--- a/neon_hub_config/main.py
+++ b/neon_hub_config/main.py
@@ -11,6 +11,7 @@ Environment Variables:
     NEON_PATH: Path to the Neon configuration file (default: "/xdg/config/mycroft/mycroft.conf")
 """
 import base64
+import errno
 import logging
 import secrets
 import string
@@ -41,6 +42,43 @@ HUB_ADMIN_TOKEN_FILE = expanduser(
     getenv("HUB_ADMIN_TOKEN_FILE", "/xdg/config/neon/hub_admin.yaml"))
 
 security = HTTPBasic()
+
+
+def _config_save_http_error(e: Exception, config_path: str) -> HTTPException:
+    """
+    Translate a config-save exception into a sanitized HTTP error.
+
+    The full traceback stays in the server logs. The client only gets a
+    stable error code and an actionable message, so no internal details
+    (stack frames, code paths) reach the UI.
+
+    Args:
+        e (Exception): The exception raised while saving
+        config_path (str): Path of the config file being written, used
+            when the exception does not carry a filename
+
+    Returns:
+        HTTPException: 500 error with detail {"error": code, "message": str}
+    """
+    path = getattr(e, "filename", None) or config_path
+    if isinstance(e, PermissionError):
+        code = "permission_denied"
+        message = (f"Permission denied writing {path}. Check the file's "
+                   "owner and permissions on the Hub, then try again.")
+    elif isinstance(e, (FileNotFoundError, NotADirectoryError,
+                        IsADirectoryError)):
+        code = "invalid_path"
+        message = (f"Cannot write {path}: the path is missing or is not "
+                   "a regular file.")
+    elif isinstance(e, OSError) and e.errno == errno.ENOSPC:
+        code = "disk_full"
+        message = f"Cannot write {path}: the disk is full."
+    else:
+        code = "save_failed"
+        message = ("An unexpected error occurred while saving. Check the "
+                   "hub-config service logs for details.")
+    return HTTPException(status_code=500,
+                         detail={"error": code, "message": message})
 
 
 class HanaClient:
@@ -191,7 +229,12 @@ class NeonHubConfigManager:
     def _load_diana_config(self) -> Dict:
         """Load Diana configuration from file, creating it with defaults if needed."""
         if not exists(self.diana_config_path):
-            self._save_diana_config(self.default_diana_config)
+            try:
+                self._save_diana_config(self.default_diana_config)
+            except Exception:
+                # Already logged; startup must not fail because the
+                # default config could not be written
+                pass
             return self.default_diana_config.copy()
 
         try:
@@ -226,6 +269,9 @@ class NeonHubConfigManager:
 
         Args:
             config (Dict): Configuration to save
+
+        Raises:
+            Exception: If the configuration cannot be written
         """
         try:
             with open(self.diana_config_path, "w+", encoding="utf-8") as file:
@@ -234,6 +280,7 @@ class NeonHubConfigManager:
                 self.yaml.dump(new_config, file)
         except Exception as e:
             self.logger.exception(f"Error saving config: {e}")
+            raise
 
     def _save_neon_user_config(self, config: Dict) -> None:
         """
@@ -241,6 +288,9 @@ class NeonHubConfigManager:
 
         Args:
             config (Dict): Configuration to save
+
+        Raises:
+            Exception: If the configuration cannot be written
         """
         try:
             with open(self.neon_user_config_path, "w+", encoding="utf-8") as file:
@@ -249,6 +299,7 @@ class NeonHubConfigManager:
                 self.yaml.dump(new_config, file)
         except Exception as e:
             self.logger.exception(f"Error saving Neon user config: {e}")
+            raise
 
     def get_neon_config(self) -> Dict:
         """
@@ -473,7 +524,12 @@ async def neon_update_config(
         Dict: Updated configuration
     """
     logger.info("Updating Neon config")
-    return manager.update_neon_config(config)
+    try:
+        return manager.update_neon_config(config)
+    except Exception as e:
+        logger.exception("Error saving Neon config")
+        raise _config_save_http_error(
+            e, manager.neon_user_config_path) from e
 
 @app.get("/v1/neon_user_config")
 async def neon_get_user_config(
@@ -506,7 +562,11 @@ async def neon_update_user_config(
         Dict: Updated configuration
     """
     logger.info("Updating Neon config")
-    manager.update_neon_user_config(config)
+    try:
+        manager.update_neon_user_config(config)
+    except Exception as e:
+        raise _config_save_http_error(
+            e, manager.neon_user_config_path) from e
     return manager.get_neon_user_config()
 
 
@@ -538,7 +598,11 @@ async def diana_update_config(
         Dict: Updated configuration
     """
     logger.info("Updating Diana config")
-    return manager.update_diana_config(config)
+    try:
+        return manager.update_diana_config(config)
+    except Exception as e:
+        raise _config_save_http_error(
+            e, manager.diana_config_path) from e
 
 
 @app.post("/v1/pair")


### PR DESCRIPTION
## Summary

When a config save failed, the UI showed only "Failed to save Neon configuration". This PR makes the save-error path informative. It addresses #9.

## Backend (`neon_hub_config/main.py`)

- The save methods for `neon.yaml` and `diana.yaml` no longer hide write errors. Before, a failed save of the user or Diana config returned HTTP 200 and the UI reported success.
- The three config POST endpoints now catch save errors. They return HTTP 500 with a stable error code and a clear message.
- The error codes are: `permission_denied`, `invalid_path`, `disk_full`, and `save_failed`.
- Each message names the file path and the corrective action. Example: "Permission denied writing /xdg/config/neon/neon.yaml. Check the file's owner and permissions on the Hub, then try again."
- The full traceback goes to the service logs only. The API response does not contain the traceback or internal code paths. This follows the security guidance in #9.

## Frontend

- The new helper `apiErrorMessage()` in `src/lib/utils.ts` reads the error detail from an API response.
- `saveNeonConfig()`, `saveDianaConfig()`, and the YAML editors now show the backend message in the existing red save-error banners. When the response has no detail, the UI shows the previous generic message.

## Deliberately out of scope

- No diagnostics panel and no "gather information" button. That is a larger feature.
- No change to the fetch/load error paths.
- No raw tracebacks in the UI, by design.

## Tests

- `tsc -b` passes for the frontend.
- A functional test with the FastAPI TestClient confirms three cases. A read-only `neon.yaml` returns `permission_denied` with the file path. A missing parent directory returns `invalid_path`. The response body contains no traceback.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
