### PR TITLE
fix(ci): publish multi-arch Docker image for linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,3 +13,5 @@ jobs:
     secrets: inherit
     with:
       image_name: ${{ github.repository }}
+      setup_qemu: true
+      platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

Closes #17.

The published Docker image had only a linux/amd64 manifest. ARM64 hosts (Apple Silicon Macs, Raspberry Pi 4/5) failed with `no matching manifest for linux/arm64/v8`. With this change, CI publishes one image with manifests for linux/amd64 and linux/arm64.

## Workflow change

The publish workflow calls the shared reusable workflow `neongeckocom/.github/.github/workflows/publish_docker.yml@master`. That workflow accepts the `platforms` and `setup_qemu` inputs. This change passes `platforms: linux/amd64,linux/arm64` and `setup_qemu: true`. The arm64 build runs under QEMU emulation on the standard `ubuntu-latest` runner. Native ARM runners are not necessary.

## Dockerfile

The Dockerfile is not changed. The base images `python:3.12` and `python:3.12-slim` are multi-arch. The build does not download binaries with a hardcoded architecture. The builder stage contains a compiler toolchain, so packages without arm64 wheels can compile.

## Verification

I ran `docker buildx build --platform linux/amd64,linux/arm64 .` locally, without `--push`. Both platform builds completed with exit code 0. I did not verify the registry push or the published manifest list. That step needs registry credentials and runs only in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
